### PR TITLE
Resolved error when package is initializing.

### DIFF
--- a/src/Gitea.VisualStudio/GiteaPackage.cs
+++ b/src/Gitea.VisualStudio/GiteaPackage.cs
@@ -110,6 +110,8 @@ namespace Gitea.VisualStudio
                 var assemblyCatalog = new AssemblyCatalog(typeof(GiteaPackage).Assembly);
                 CompositionContainer container = new CompositionContainer(assemblyCatalog);
                 container.ComposeParts(this);
+                // Added the following line to prevent the error "Due to high risk of deadlock you cannot call GetService from a background thread in an AsyncPackage derived class"
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 var mcs = await GetServiceAsync(typeof(IMenuCommandService)) as OleMenuCommandService;
                 if (mcs != null)
                 {


### PR DESCRIPTION
I was receiving an error when GiteaPackage was initializing. "Due to high risk of deadlock you cannot call GetService from a background thread in an AsyncPackage derived class".
I added a SwitchToMainThreadAsync above the var mcs = await GetServiceAsync(typeof(IMenuCommandService)) as OleMenuCommandService; That seems to resolve it.