### PR TITLE
Storage.Host to return Configuration.Host.

### DIFF
--- a/src/Gitea.VisualStudio/Services/Storage.cs
+++ b/src/Gitea.VisualStudio/Services/Storage.cs
@@ -33,24 +33,25 @@ namespace Gitea.VisualStudio.Services
         {
             get
             {
-                string url = string.Empty;
-                using (var git = new GitAnalysis(GiteaPackage.GetSolutionDirectory()))
-                {
-                    if (git != null && git.IsDiscoveredGitRepository)
-                    {
-                        string hurl = git.GetRepoUrlRoot();
-                        if (!string.IsNullOrEmpty(hurl))
-                        {
-                            Uri uri = new Uri(hurl);
-                            url = $"{uri.Scheme}://{uri.Host}{(uri.Port == 80 || uri.Port == 443 ? "" : $":{uri.Port}")}";
-                        }
-                    }
-                }
-                if (string.IsNullOrEmpty(url))
-                {
-                    url = Configuration.Host;
-                }
-                return url;
+                return Configuration.Host;
+                //string url = string.Empty;
+                //using (var git = new GitAnalysis(GiteaPackage.GetSolutionDirectory()))
+                //{
+                //    if (git != null && git.IsDiscoveredGitRepository)
+                //    {
+                //        string hurl = git.GetRepoUrlRoot();
+                //        if (!string.IsNullOrEmpty(hurl))
+                //        {
+                //            Uri uri = new Uri(hurl);
+                //            url = $"{uri.Scheme}://{uri.Host}{(uri.Port == 80 || uri.Port == 443 ? "" : $":{uri.Port}")}";
+                //        }
+                //    }
+                //}
+                //if (string.IsNullOrEmpty(url))
+                //{
+                //    url = Configuration.Host;
+                //}
+                //return url;
             }
         }
         public string Path


### PR DESCRIPTION
I found that if I have a git project open, that wasn't a Gitea repo, sections would no longer show that I was connected to Gitea.