### PR TITLE
Clone descriptions

### DIFF
--- a/src/Gitea.TeamFoundation.14/Views/ConnectSectionView.xaml
+++ b/src/Gitea.TeamFoundation.14/Views/ConnectSectionView.xaml
@@ -313,6 +313,28 @@
                   VirtualizingPanel.ScrollUnit="Pixel"
                   VirtualizingPanel.IsVirtualizingWhenGrouping="True"
                   Visibility="{Binding IsRepositoriesVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <ListView.ContextMenu>
+                <ContextMenu>
+                    <MenuItem Header="Open"
+                              Command="{Binding OpenRepositoryCommand}"
+                              CommandParameter="{Binding SelectedRepository}">
+                        <MenuItem.Icon>
+                            <controls:OcticonImage
+                                Foreground="#FFF4C9"
+                                Icon="file_directory"/>
+                        </MenuItem.Icon>
+                    </MenuItem>
+                    <Separator/>
+                    <MenuItem Header="Delete Local"
+                              Command="{Binding DeleteLocalRepoCommand}"
+                              CommandParameter="{Binding SelectedRepository}">
+                        <MenuItem.Icon>
+                            <controls:OcticonImage Icon="trashcan"
+                                                   Foreground="#F05033"/>
+                        </MenuItem.Icon>
+                    </MenuItem>
+                </ContextMenu>
+            </ListView.ContextMenu>
             <i:Interaction.Triggers>
                 <i:EventTrigger EventName="MouseDoubleClick">
                     <i:InvokeCommandAction Command="{Binding OpenRepositoryCommand}"

--- a/src/Gitea.VisualStudio.Shared/Gitea.VisualStudio.Shared.csproj
+++ b/src/Gitea.VisualStudio.Shared/Gitea.VisualStudio.Shared.csproj
@@ -178,6 +178,7 @@
     <Compile Include="IViewFactory.cs" />
     <Compile Include="IShellService.cs" />
     <Compile Include="IWebService.cs" />
+    <Compile Include="NativeMethods.cs" />
     <Compile Include="NotificationAwareObject.cs" />
     <Compile Include="..\common\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>

--- a/src/Gitea.VisualStudio.Shared/IWebService.cs
+++ b/src/Gitea.VisualStudio.Shared/IWebService.cs
@@ -73,6 +73,7 @@ namespace Gitea.VisualStudio.Shared
                     HttpUrl = p.CloneUrl,
                     IssuesEnabled = true,
                     Name = p.Name,
+                    Description = p.Description,
                     Owner = p.Owner,
                     Public = !p.IsPrivate,
                     SnippetsEnabled = false,
@@ -94,7 +95,7 @@ namespace Gitea.VisualStudio.Shared
 
 
         public string Name { get; set; }
-
+        public string Description { get; set; }
         public string Path { get; set; }
 
         public bool Public { get; set; }

--- a/src/Gitea.VisualStudio.Shared/NativeMethods.cs
+++ b/src/Gitea.VisualStudio.Shared/NativeMethods.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Gitea.VisualStudio.Shared
+{
+    public static class NativeMethods
+    {
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto, Pack = 1)]
+        public struct SHFILEOPSTRUCT
+        {
+            public IntPtr hwnd;
+            [MarshalAs(UnmanagedType.U4)] public int wFunc;
+            public string pFrom;
+            public string pTo;
+            public short fFlags;
+            [MarshalAs(UnmanagedType.Bool)] public bool fAnyOperationsAborted;
+            public IntPtr hNameMappings;
+            public string lpszProgressTitle;
+        }
+
+        [DllImport("shell32.dll", CharSet = CharSet.Auto)]
+        public static extern int SHFileOperation(ref SHFILEOPSTRUCT FileOp);
+        public const int FO_DELETE = 3;
+        public const int FOF_ALLOWUNDO = 0x40;
+        public const int FOF_NOCONFIRMATION = 0x10;    //Don't prompt the user.; 
+    }
+}

--- a/src/Gitea.VisualStudio.UI/ViewModels/CloneViewModel.cs
+++ b/src/Gitea.VisualStudio.UI/ViewModels/CloneViewModel.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Data;
@@ -56,7 +57,18 @@ namespace Gitea.VisualStudio.UI.ViewModels
         private bool RepoFilter(object item)
         {
             var repo = item as ProjectViewModel;
-            return string.IsNullOrEmpty(FilterText) ? true : repo.Name.ToLower().Contains(FilterText.ToLower());
+            
+            if (string.IsNullOrEmpty(FilterText))
+            {
+                return true;
+            }
+            else
+            {
+                var compare = CultureInfo.CurrentCulture.CompareInfo;
+                return compare.IndexOf(repo.Name, FilterText, CompareOptions.IgnoreCase) != -1
+                    || compare.IndexOf(repo.Description, FilterText, CompareOptions.IgnoreCase) != -1;
+            }
+            
         }
 
         private string _filterText;

--- a/src/Gitea.VisualStudio.UI/ViewModels/ProjectViewModel.cs
+++ b/src/Gitea.VisualStudio.UI/ViewModels/ProjectViewModel.cs
@@ -36,16 +36,26 @@ namespace Gitea.VisualStudio.UI.ViewModels
     public class ProjectViewModel
     {
         public string Name { get; set; }
+        public string Description { get; set; }
         public string Url { get; set; }
         public Owner Owner { get; set; }
         public Octicon Icon { get; set; }
-
+        public System.Windows.Visibility DescriptionVisibility
+        {
+            get
+            {
+                return string.IsNullOrWhiteSpace(Description) 
+                    ? System.Windows.Visibility.Collapsed 
+                    : System.Windows.Visibility.Visible;
+            }
+        }
         public bool IsActive { get; set; }
 
         public ProjectViewModel(Project repository)
         {
             Name = repository.Name;
             Url = repository.Url;
+            Description = repository.Description;
 
             if (repository.Owner != null)
             {

--- a/src/Gitea.VisualStudio.UI/Views/CloneView.xaml
+++ b/src/Gitea.VisualStudio.UI/Views/CloneView.xaml
@@ -258,11 +258,23 @@
                                                            VerticalAlignment="Center"
                                                            Foreground="#D0D0D0"
                                                            Icon="{Binding Icon}" />
-                                    <TextBlock x:Name="label"
-                                               VerticalAlignment="Center"
-                                               Foreground="#666"
-                                               Text="{Binding Name}"
-                                               TextTrimming="CharacterEllipsis" />
+                                    <StackPanel>
+                                        <TextBlock x:Name="label"
+                                                   VerticalAlignment="Center"
+                                                   Foreground="Black"
+                                                   Text="{Binding Name}"
+                                                   TextTrimming="CharacterEllipsis"
+                                                   MaxWidth="275" />
+                                        <TextBlock VerticalAlignment="Center"
+                                                   Foreground="#666"
+                                                   Text="{Binding Description}"
+                                                   Visibility="{Binding DescriptionVisibility}"
+                                                   TextTrimming="CharacterEllipsis"
+                                                   FontSize="9"
+                                                   MaxWidth="275"
+                                                   
+                                               />
+                                    </StackPanel>
                                 </StackPanel>
                             </Border>
                         </DataTemplate>

--- a/src/Gitea.VisualStudio.UI/Views/CloneView.xaml
+++ b/src/Gitea.VisualStudio.UI/Views/CloneView.xaml
@@ -256,7 +256,7 @@
                                                            Height="16"
                                                            Margin="32,0,6,0"
                                                            VerticalAlignment="Center"
-                                                           Foreground="#D0D0D0"
+                                                           Foreground="#919191"
                                                            Icon="{Binding Icon}" />
                                     <StackPanel>
                                         <TextBlock x:Name="label"


### PR DESCRIPTION
Hello,
My co-workers asked for a couple of features to be added.
This request includes the following changes:
- First line of the repository descriptions are shown in the clone window. (if they are not empty)
- Context menu added to the repository list of the ConnectionSectionView for opening or deleting the local repository.
![repo with description](https://user-images.githubusercontent.com/14047448/53763923-ef774400-3e99-11e9-81c5-4717d4114cb7.png)
![repo context menu](https://user-images.githubusercontent.com/14047448/53763950-0322aa80-3e9a-11e9-891e-9655c19d80f9.png)
