### PR TITLE
Allow for private repositories to be made

### DIFF
--- a/src/Gitea.VisualStudio/Services/WebService.cs
+++ b/src/Gitea.VisualStudio/Services/WebService.cs
@@ -112,6 +112,7 @@ namespace Gitea.VisualStudio.Services
                     .Name(name)
                     .Description(description)
                     .MakeAutoInit(false)
+                    .MakePrivate(isPrivate)
                     .Owner(owner.UserName, owner.OwnerType == OwnershipTypes.Organization)
                      .Start();
                 result.Project = (Project)pjt;


### PR DESCRIPTION
This enables users to make private repositories through the UI. Utilising the Gitea API to ensure that if the user selects for a `Private` repository in the extension window, it will create it as private.

\* **Note:** This is untested as I am on a Linux machine; this issue was raised by a colleague who is unable to build the program solution on their environment.